### PR TITLE
chore: add security-review skill to config and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,4 +100,5 @@ super-linter-output
 /.claude/skills/git-safety
 /.claude/skills/pr-workflow
 /.claude/skills/commit-standards
+/.claude/skills/security-review
 # end managed by holocron setup — skills

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -17,5 +17,5 @@ export default defineConfig({
 		secrets: "github",
 	},
 	agent: "claude",
-	skills: ["git-safety", "pr-workflow", "commit-standards"],
+	skills: ["git-safety", "pr-workflow", "commit-standards", "security-review"],
 } satisfies HolocronConfig);


### PR DESCRIPTION
## Summary

- Adds `"security-review"` to the `skills` array in `holocron.config.ts` to match the other repos in the org
- Adds `/.claude/skills/security-review` to the `# managed by holocron setup — skills` block in `.gitignore`

Note: `codeql` and `test` workflows are intentionally absent — this is a static Astro site with no code to scan or test suite to run. Root-level `dist/` and `.astro/` are already covered in `.gitignore`.

## Test plan

- [ ] Confirm `security-review` skill is available after running `holocron setup` locally

Refs theholocron/holocron#288