### PR TITLE
fix(eslint): allow triple-slash path reference in Astro-generated env.d.ts

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,6 +1,17 @@
 import { base, typescript } from "@theholocron/eslint-config";
 import type { Linter } from "eslint";
 
-const config = [...base(), ...typescript(), { ignores: [".astro/**", "dist/**"] }] satisfies Linter.Config[];
+const config = [
+	...base(),
+	...typescript(),
+	{
+		files: ["src/env.d.ts"],
+		rules: {
+			// Astro generates env.d.ts with /// <reference path> — this is intentional.
+			"@typescript-eslint/triple-slash-reference": "off",
+		},
+	},
+	{ ignores: [".astro/**", "dist/**"] },
+] satisfies Linter.Config[];
 
 export default config;


### PR DESCRIPTION
## Summary

Astro generates `src/env.d.ts` with `/// <reference path="../.astro/types.d.ts" />` as part of its type-checking setup. This is intentional Astro convention and cannot be replaced with an `import`.

The `@typescript-eslint/triple-slash-reference` rule was flagging this file. Adding a file-specific override to disable the rule for `src/env.d.ts` only.

Unblocks: #111